### PR TITLE
Support GitHub Enterprise Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,30 +118,6 @@ Default: `1`
 
 How many releases of changelog you want to generate. It counts from the latest semver tag. Useful when you forgot to generate any previous releases. Set to `0` to regenerate all.
 
-##### host
-
-Default: `api.github.com`
-
-Github API hostname
-
-##### pathPrefix
-
-Default: `none`
-
-Github API pathPrefix 
-
-##### protocol
-
-Default: `https`
-
-Github API protocol 
-
-##### port
-
-Default: `80 (http), 443 (https)`
-
-Github API port
-
 #### context
 
 Default: `none`
@@ -159,8 +135,6 @@ Default: based on `options.releaseCount`.
 Default: latest semver tag
 
 #### writerOpts
-
-#### parserOpts
 
 ##### includeDetails
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Default: latest semver tag
 
 #### writerOpts
 
+#### parserOpts
+
 ##### includeDetails
 
 It is always `true`.
@@ -167,12 +169,6 @@ It is always `true`.
 ##### headerPartial
 
 If there is any preset, this defaults to `''` because header in presets usually contains the version and date which are already in the release.
-
-#### parserOpts
-
-Default: `none`
-
-A object that is used to define how conventional changelog will parse the commits
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ Default: `1`
 
 How many releases of changelog you want to generate. It counts from the latest semver tag. Useful when you forgot to generate any previous releases. Set to `0` to regenerate all.
 
+##### host
+
+Default: `api.github.com`
+
+Github API hostname
+
+##### pathPrefix
+
+Default: `none`
+
+Github API pathPrefix 
+
+##### protocol
+
+Default: `https`
+
+Github API protocol 
+
+##### port
+
+Default: `80 (http), 443 (https)`
+
+Github API port
+
+#### context
+
+Default: `none`
+
+A object that is used to define conventional changelog template variables
+
 #### gitRawCommitsOpts
 
 ##### from
@@ -138,6 +168,11 @@ It is always `true`.
 
 If there is any preset, this defaults to `''` because header in presets usually contains the version and date which are already in the release.
 
+#### parserOpts
+
+Default: `none`
+
+A object that is used to define how conventional changelog will parse the commits
 
 ## CLI
 

--- a/cli.js
+++ b/cli.js
@@ -91,7 +91,7 @@ var auth = {
 };
 
 var githubKeys = ['host', 'pathPrefix', 'protocol', 'port'];
-var changelogOpts = githubKeys.
+var options = githubKeys.
   reduce(function(config, key) {
     if (flags[key]) {
       config[key] = flags[key].toString();
@@ -107,11 +107,11 @@ var changelogOpts = githubKeys.
   });
 
 if (flags.verbose) {
-  changelogOpts.debug = console.info.bind(console);
-  changelogOpts.warn = console.warn.bind(console);
+  options.debug = console.info.bind(console);
+  options.warn = console.warn.bind(console);
 }
 
-conventionalGithubReleaser(auth, changelogOpts, templateContext, function(err, data) {
+conventionalGithubReleaser(auth, options, templateContext, function(err, data) {
   if (err) {
     console.error(err.toString());
     process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -33,17 +33,16 @@ var cli = meow({
     '',
     '  -c, --context             A filepath of a javascript that is used to define template variables',
     '',
-    'Options ( Github Enterprise )',
-    '  --github-host              Github host name',
+    '  --host                    Github host name',
     '                            Default: api.github.com',
     '',
-    '  --github-path-prefix       Github api path prefix',
+    '  --path-prefix             Github api path prefix',
     '                            Default: none',
     '',
-    '  --github-protocol          Github protocoll',
+    '  --protocol                Github protocol',
     '                            Default: https',
     '',
-    '  --github-port              Github port',
+    '  --port                    Github port',
     '                            Default: 80 (http), 443 (https)',
   ]
 }, {
@@ -86,29 +85,25 @@ try {
   process.exit(1);
 }
 
-var changelogOpts = {
-  preset: flags.preset,
-  pkg: {
-    path: flags.pkg
-  },
-  releaseCount: flags.releaseCount,
-  config: flags.config
+var auth = {
+  type: 'oauth',
+  token: flags.token || process.env.CONVENTIONAL_GITHUB_RELEASER_TOKEN
 };
 
-var githubOpts = Object.
-  keys(flags).
-  filter(function(key) {
-    return /github/.test(key);
-  }).
+var githubKeys = ['host', 'pathPrefix', 'protocol', 'port'];
+var changelogOpts = githubKeys.
   reduce(function(config, key) {
-    var prop = key.replace(/github([A-Z])/, function(m, char) {
-      return char.toLowerCase();
-    });
-    config[prop] = flags[key].toString();
+    if (flags[key]) {
+      config[key] = flags[key].toString();
+    }
     return config;
-  }, {
-    type: 'oauth',
-    token: flags.token || process.env.CONVENTIONAL_GITHUB_RELEASER_TOKEN
+  },{
+    preset: flags.preset,
+    pkg: {
+      path: flags.pkg
+    },
+    releaseCount: flags.releaseCount,
+    config: flags.config
   });
 
 if (flags.verbose) {
@@ -116,7 +111,7 @@ if (flags.verbose) {
   changelogOpts.warn = console.warn.bind(console);
 }
 
-conventionalGithubReleaser(githubOpts, changelogOpts, templateContext, function(err, data) {
+conventionalGithubReleaser(auth, changelogOpts, templateContext, function(err, data) {
   if (err) {
     console.error(err.toString());
     process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -95,21 +95,21 @@ var changelogOpts = {
   config: flags.config
 };
 
-var githubOpts = Object
-  .keys(flags)
-  .filter(function (key) {
-    return /github/.test(key)
-  })
-  .reduce(function (config, key) {
-    var prop = key.replace(/github([A-Z])/, function (m, char) {
-      return char.toLowerCase()
-    })
-    config[prop] = flags[key].toString()
-    return config
+var githubOpts = Object.
+  keys(flags).
+  filter(function(key) {
+    return /github/.test(key);
+  }).
+  reduce(function(config, key) {
+    var prop = key.replace(/github([A-Z])/, function(m, char) {
+      return char.toLowerCase();
+    });
+    config[prop] = flags[key].toString();
+    return config;
   }, {
     type: 'oauth',
     token: flags.token || process.env.CONVENTIONAL_GITHUB_RELEASER_TOKEN
-  })
+  });
 
 if (flags.verbose) {
   changelogOpts.debug = console.info.bind(console);

--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,20 @@ var cli = meow({
     '                            Example of a config script: https://github.com/stevemao/conventional-changelog-angular/blob/master/index.js',
     '                            This value is ignored if preset is specified',
     '',
-    '  -c, --context             A filepath of a javascript that is used to define template variables'
+    '  -c, --context             A filepath of a javascript that is used to define template variables',
+    '',
+    'Options ( Github Enterprise )',
+    '  --github-host              Github host name',
+    '                            Default: api.github.com',
+    '',
+    '  --github-path-prefix       Github api path prefix',
+    '                            Default: none',
+    '',
+    '  --github-protocol          Github protocoll',
+    '                            Default: https',
+    '',
+    '  --github-port              Github port',
+    '                            Default: 80 (http), 443 (https)',
   ]
 }, {
   alias: {
@@ -82,15 +95,28 @@ var changelogOpts = {
   config: flags.config
 };
 
+var githubOpts = Object
+  .keys(flags)
+  .filter(function (key) {
+    return /github/.test(key)
+  })
+  .reduce(function (config, key) {
+    var prop = key.replace(/github([A-Z])/, function (m, char) {
+      return char.toLowerCase()
+    })
+    config[prop] = flags[key].toString()
+    return config
+  }, {
+    type: 'oauth',
+    token: flags.token || process.env.CONVENTIONAL_GITHUB_RELEASER_TOKEN
+  })
+
 if (flags.verbose) {
   changelogOpts.debug = console.info.bind(console);
   changelogOpts.warn = console.warn.bind(console);
 }
 
-conventionalGithubReleaser({
-  type: 'oauth',
-  token: flags.token || process.env.CONVENTIONAL_GITHUB_RELEASER_TOKEN
-}, changelogOpts, templateContext, function(err, data) {
+conventionalGithubReleaser(githubOpts, changelogOpts, templateContext, function(err, data) {
   if (err) {
     console.error(err.toString());
     process.exit(1);

--- a/index.js
+++ b/index.js
@@ -9,18 +9,18 @@ var Q = require('q');
 var semver = require('semver');
 var through = require('through2');
 
-function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
+function conventionalGithubReleaser(auth, options, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
   if (!auth) {
     throw new Error('Expected an auth object');
   }
 
   var github = new Github(Object.assign({
     version: '3.0.0'
-  }, changelogOpts));
+  }, options));
 
   var promises = [];
 
-  var changelogArgs = [changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts].map(function(arg) {
+  var changelogArgs = [options, context, gitRawCommitsOpts, parserOpts, writerOpts].map(function(arg) {
     if (typeof arg === 'function') {
       userCb = arg;
       return {};
@@ -33,13 +33,13 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
     throw new Error('Expected an callback');
   }
 
-  changelogOpts = changelogArgs[0];
+  options = changelogArgs[0];
   context = changelogArgs[1];
   gitRawCommitsOpts = changelogArgs[2];
   parserOpts = changelogArgs[3];
   writerOpts = changelogArgs[4];
 
-  changelogOpts = merge({
+  options = merge({
     transform: function(chunk, cb) {
       if (typeof chunk.gitTags === 'string') {
         var match = /tag:\s*(.+?)[,\)]/gi.exec(chunk.gitTags);
@@ -55,7 +55,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
       cb(null, chunk);
     },
     releaseCount: 1
-  }, changelogOpts);
+  }, options);
 
   writerOpts.includeDetails = true;
 
@@ -71,7 +71,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
         return;
       }
 
-      var releaseCount = changelogOpts.releaseCount;
+      var releaseCount = options.releaseCount;
       if (releaseCount !== 0) {
         gitRawCommitsOpts = assign({
           from: tags[releaseCount]
@@ -80,7 +80,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
 
       gitRawCommitsOpts.to = gitRawCommitsOpts.to || tags[0];
 
-      conventionalChangelog(changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts)
+      conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, writerOpts)
         .on('error', function(err) {
           userCb(err);
         })

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var merge = require('lodash.merge');
 var Q = require('q');
 var semver = require('semver');
 var through = require('through2');
-var parse = require('@bahmutov/parse-github-repo-url')
+var parse = require('@bahmutov/parse-github-repo-url');
 
 function conventionalGithubReleaser(githubOpts, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
   if (!githubOpts || !githubOpts.token) {
@@ -97,7 +97,7 @@ function conventionalGithubReleaser(githubOpts, changelogOpts, context, gitRawCo
 
           // conventional changelog don't parse
           // owner of ghe reposity yet
-          var owner = parse(context.repository)[1]
+          var owner = parse(context.repository)[1];
 
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var merge = require('lodash.merge');
 var Q = require('q');
 var semver = require('semver');
 var through = require('through2');
-var parse = require('@bahmutov/parse-github-repo-url');
+var parseSlug = require('@bahmutov/parse-github-repo-url');
 
 function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
   if (!auth) {
@@ -96,12 +96,16 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
           var prerelease = semver.parse(version).prerelease.length > 0;
 
           // conventional changelog don't parse
-          // owner of ghe reposity yet
-          var owner = parse(context.repository)[1];
+          // owner/repo of ghe reposity yet
+          if (!context.owner) {
+            var parts = parseSlug(context.repository);
+            context.owner = parts[0];
+            context.repository = parts[1];
+          }
 
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
-            owner: context.owner || owner,
+            owner: context.owner,
             repo: context.repository,
             tag_name: version,
             body: chunk.log,

--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ var semver = require('semver');
 var through = require('through2');
 var parse = require('@bahmutov/parse-github-repo-url');
 
-function conventionalGithubReleaser(githubOpts, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
-  if (!githubOpts || !githubOpts.token) {
+function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
+  if (!auth) {
     throw new Error('Expected an auth object');
   }
 
   var github = new Github(Object.assign({
     version: '3.0.0'
-  }, githubOpts));
+  }, changelogOpts));
 
   var promises = [];
 
@@ -63,7 +63,7 @@ function conventionalGithubReleaser(githubOpts, changelogOpts, context, gitRawCo
   // ignore the default header partial
   writerOpts.headerPartial = writerOpts.headerPartial || '';
 
-  github.authenticate(githubOpts);
+  github.authenticate(auth);
 
   Q.nfcall(gitSemverTags)
     .then(function(tags) {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function conventionalGithubReleaser(auth, options, context, gitRawCommitsOpts, p
     throw new Error('Expected an auth object');
   }
 
-  var github = new Github(Object.assign({
+  var github = new Github(assign({
     version: '3.0.0'
   }, options));
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var merge = require('lodash.merge');
 var Q = require('q');
 var semver = require('semver');
 var through = require('through2');
-var parseSlug = require('@bahmutov/parse-github-repo-url');
 
 function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsOpts, parserOpts, writerOpts, userCb) {
   if (!auth) {
@@ -94,14 +93,6 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
           var version =  chunk.keyCommit.version;
 
           var prerelease = semver.parse(version).prerelease.length > 0;
-
-          // conventional changelog don't parse
-          // owner/repo of ghe reposity yet
-          if (!context.owner) {
-            var parts = parseSlug(context.repository);
-            context.owner = parts[0];
-            context.repository = parts[1];
-          }
 
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable

--- a/package.json
+++ b/package.json
@@ -57,8 +57,5 @@
   },
   "bin": {
     "conventional-github-releaser": "cli.js"
-  },
-  "engines": {
-    "node": ">= 4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "log"
   ],
   "dependencies": {
+    "@bahmutov/parse-github-repo-url": "^0.1.1",
     "conventional-changelog": "^1.1.0",
     "dateformat": "^1.0.11",
     "git-semver-tags": "^1.0.0",
@@ -46,7 +47,9 @@
     "jscs": "^2.0.0",
     "jshint": "^2.9.1",
     "mocha": "*",
-    "shelljs": "^0.6.0"
+    "proxyquire": "^1.7.4",
+    "shelljs": "^0.6.0",
+    "sinon": "^1.17.3"
   },
   "scripts": {
     "coverage": "istanbul cover _mocha -- -R spec --timeout 50000 && rm -rf ./coverage",
@@ -55,5 +58,8 @@
   },
   "bin": {
     "conventional-github-releaser": "cli.js"
+  },
+  "engines": {
+    "node": ">= 4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "log"
   ],
   "dependencies": {
-    "@bahmutov/parse-github-repo-url": "^0.1.1",
     "conventional-changelog": "^1.1.0",
     "dateformat": "^1.0.11",
     "git-semver-tags": "^1.0.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -7,8 +7,8 @@ var spawn = require('child_process').spawn;
 var concat = require('concat-stream');
 
 var cliPath = __dirname + '/../cli.js';
-var repo = require('./fixtures').repo
-var AUTH = require('./fixtures').auth
+var repo = require('./fixtures').repo;
+var AUTH = require('./fixtures').auth;
 
 describe('cli', function() {
   before(function(done) {
@@ -18,8 +18,8 @@ describe('cli', function() {
     shell.exec('git add --all && git commit -m"First commit"');
     shell.exec('git tag v0.0.1');
 
-    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function () {
-      done()
+    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function() {
+      done();
     });
   });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -7,11 +7,8 @@ var spawn = require('child_process').spawn;
 var concat = require('concat-stream');
 
 var cliPath = __dirname + '/../cli.js';
-
-var AUTH = {
-  type: 'oauth',
-  token: process.env.TEST_CONVENTIONAL_GITHUB_RELEASER_TOKEN
-};
+var repo = require('./fixtures').repo
+var AUTH = require('./fixtures').auth
 
 describe('cli', function() {
   before(function(done) {
@@ -21,8 +18,8 @@ describe('cli', function() {
     shell.exec('git add --all && git commit -m"First commit"');
     shell.exec('git tag v0.0.1');
 
-    githubRemoveAllReleases(AUTH, 'stevemaotest', 'conventional-github-releaser-test', function() {
-      done();
+    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function () {
+      done()
     });
   });
 
@@ -64,7 +61,7 @@ describe('cli', function() {
   });
 
   it('should print out error message and exit with `1` if all results error when verbose', function(done) {
-    var cp = spawn(cliPath, ['--pkg',  __dirname + '/fixtures/_package.json', '-t', AUTH.token, '-v'], {
+    var cp = spawn(cliPath, ['--pkg',  repo.pkg.path, '-t', AUTH.token, '-v'], {
       stdio: [process.stdin, null, null]
     });
 
@@ -84,7 +81,7 @@ describe('cli', function() {
     shell.exec('git add --all && git commit -m"Second commit"');
     shell.exec('git tag v0.0.2');
 
-    var cp = spawn(cliPath, ['--pkg',  __dirname + '/fixtures/_package.json', '-t', AUTH.token, '-r', '0'], {
+    var cp = spawn(cliPath, ['--pkg',  repo.pkg.path, '-t', AUTH.token, '-r', '0'], {
       stdio: [process.stdin, null, null]
     });
 
@@ -96,7 +93,7 @@ describe('cli', function() {
   });
 
   it('should exit with `1` if all results error', function(done) {
-    var cp = spawn(cliPath, ['--pkg',  __dirname + '/fixtures/_package.json', '-t', AUTH.token, '-r', '0'], {
+    var cp = spawn(cliPath, ['--pkg',  repo.pkg.path, '-t', AUTH.token, '-r', '0'], {
       stdio: [process.stdin, null, null]
     });
 

--- a/test/fixtures/_ghe_package.json
+++ b/test/fixtures/_ghe_package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ghe-repo",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "http://github.mycompany.dev/programmer/ghe-repo.git"
+  }
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,8 +1,8 @@
 module.exports.repo = {
   owner: 'stevemaotest',
   name: 'conventional-github-releaser-test',
-  pkg: { path: __dirname + '/_package.json' }
-}
+  pkg: {path: __dirname + '/_package.json'}
+};
 
 module.exports.auth = {
   type: 'oauth',

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,10 @@
+module.exports.repo = {
+  owner: 'stevemaotest',
+  name: 'conventional-github-releaser-test',
+  pkg: { path: __dirname + '/_package.json' }
+}
+
+module.exports.auth = {
+  type: 'oauth',
+  token: process.env.TEST_CONVENTIONAL_GITHUB_RELEASER_TOKEN
+};

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -4,6 +4,12 @@ module.exports.repo = {
   pkg: {path: __dirname + '/_package.json'}
 };
 
+module.exports.ghe = {
+  owner: 'programmer',
+  name: 'ghe-repo',
+  pkg: {path: __dirname + '/_ghe_package.json'}
+};
+
 module.exports.auth = {
   type: 'oauth',
   token: process.env.TEST_CONVENTIONAL_GITHUB_RELEASER_TOKEN

--- a/test/ghe.js
+++ b/test/ghe.js
@@ -1,74 +1,74 @@
 var proxyquire = require('proxyquire').noPreserveCache();
-var sinon = require('sinon')
+var sinon = require('sinon');
 var expect = require('chai').expect;
 
-var auth = { token: " any token", type: "oauth" }
+var auth = {token: ' any token', type: 'oauth'};
 
-describe('Github Enterprise', function () {
-  describe('cli', function () {
-    var release = sinon.spy()
+describe('Github Enterprise', function() {
+  describe('cli', function() {
+    var release = sinon.spy();
     // run the cli with stub
     // conventionalGithubReleaser
     var run = function(args) {
-      process.argv = ['node', 'cli'].concat(args)
-      proxyquire('../cli', { './' : release })
-    }
+      process.argv = ['node', 'cli'].concat(args);
+      proxyquire('../cli', {'./': release});
+    };
 
-    afterEach(function () {
-      release.reset()
-    })
+    afterEach(function() {
+      release.reset();
+    });
 
-    it('should accept github-* params', function () {
+    it('should accept github-* params', function() {
       run([
         '-t' +  auth.token,
         '--github-port', '80',
         '--github-protocol', 'https',
         '--github-host', 'github.com',
         '--github-path-prefix', '/api/v3'
-      ])
+      ]);
 
       expect(release.getCall(0).args[0]).to.eql({
         token: auth.token,
         type: auth.type,
-        host: "github.com",
-        pathPrefix: "/api/v3",
-        port: "80",
-        protocol: "https"
-      })
-    })
+        host: 'github.com',
+        pathPrefix: '/api/v3',
+        port: '80',
+        protocol: 'https'
+      });
+    });
 
-    it('should github-* empty', function () {
-      run([ '-t',  auth.token])
+    it('should github-* empty', function() {
+      run(['-t', auth.token]);
 
       expect(release.getCall(0).args[0]).to.eql({
         token: auth.token,
         type: auth.type,
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('library', function () {
-    var GitHub = sinon.spy()
-    var release = proxyquire('../index', { 'github' : GitHub })
+  describe('library', function() {
+    var GitHub = sinon.spy();
+    var release = proxyquire('../index', {'github': GitHub});
 
-    afterEach(function () {
-      GitHub.reset()
-    })
+    afterEach(function() {
+      GitHub.reset();
+    });
 
-    it('should accept ghe params', function () {
-      var changelogOpts = {}
-      var context = {}
-      var gitRawCommitsOpts = {}
-      var parserOpts = {}
-      var writerOpts = {}
-      var cb = sinon.spy()
+    it('should accept ghe params', function() {
+      var changelogOpts = {};
+      var context = {};
+      var gitRawCommitsOpts = {};
+      var parserOpts = {};
+      var writerOpts = {};
+      var cb = sinon.spy();
 
       var githubOpts = Object.assign({
-        host: "github.com",
-        pathPrefix: "/api/v3",
-        port: "80",
-        protocol: "https"
-      }, auth)
+        host: 'github.com',
+        pathPrefix: '/api/v3',
+        port: '80',
+        protocol: 'https'
+      }, auth);
 
       release(
         githubOpts,
@@ -78,11 +78,11 @@ describe('Github Enterprise', function () {
         parserOpts,
         writerOpts,
         cb
-      )
+      );
 
       expect(GitHub.getCall(0).args[0]).to.eql(Object.assign(githubOpts, {
         version: '3.0.0'
-      }))
-    })
-  })
-})
+      }));
+    });
+  });
+});

--- a/test/ghe.js
+++ b/test/ghe.js
@@ -1,0 +1,88 @@
+var proxyquire = require('proxyquire').noPreserveCache();
+var sinon = require('sinon')
+var expect = require('chai').expect;
+
+var auth = { token: " any token", type: "oauth" }
+
+describe('Github Enterprise', function () {
+  describe('cli', function () {
+    var release = sinon.spy()
+    // run the cli with stub
+    // conventionalGithubReleaser
+    var run = function(args) {
+      process.argv = ['node', 'cli'].concat(args)
+      proxyquire('../cli', { './' : release })
+    }
+
+    afterEach(function () {
+      release.reset()
+    })
+
+    it('should accept github-* params', function () {
+      run([
+        '-t' +  auth.token,
+        '--github-port', '80',
+        '--github-protocol', 'https',
+        '--github-host', 'github.com',
+        '--github-path-prefix', '/api/v3'
+      ])
+
+      expect(release.getCall(0).args[0]).to.eql({
+        token: auth.token,
+        type: auth.type,
+        host: "github.com",
+        pathPrefix: "/api/v3",
+        port: "80",
+        protocol: "https"
+      })
+    })
+
+    it('should github-* empty', function () {
+      run([ '-t',  auth.token])
+
+      expect(release.getCall(0).args[0]).to.eql({
+        token: auth.token,
+        type: auth.type,
+      })
+    })
+  })
+
+  describe('library', function () {
+    var GitHub = sinon.spy()
+    var release = proxyquire('../index', { 'github' : GitHub })
+
+    afterEach(function () {
+      GitHub.reset()
+    })
+
+    it('should accept ghe params', function () {
+      var changelogOpts = {}
+      var context = {}
+      var gitRawCommitsOpts = {}
+      var parserOpts = {}
+      var writerOpts = {}
+      var cb = sinon.spy()
+
+      var githubOpts = Object.assign({
+        host: "github.com",
+        pathPrefix: "/api/v3",
+        port: "80",
+        protocol: "https"
+      }, auth)
+
+      release(
+        githubOpts,
+        changelogOpts,
+        context,
+        gitRawCommitsOpts,
+        parserOpts,
+        writerOpts,
+        cb
+      )
+
+      expect(GitHub.getCall(0).args[0]).to.eql(Object.assign(githubOpts, {
+        version: '3.0.0'
+      }))
+    })
+  })
+})

--- a/test/ghe.js
+++ b/test/ghe.js
@@ -18,18 +18,21 @@ describe('Github Enterprise', function() {
       release.reset();
     });
 
-    it('should accept github-* params', function() {
+    it('should accept http releated params', function() {
       run([
         '-t' +  auth.token,
-        '--github-port', '80',
-        '--github-protocol', 'https',
-        '--github-host', 'github.com',
-        '--github-path-prefix', '/api/v3'
+        '--port', '80',
+        '--protocol', 'https',
+        '--host', 'github.com',
+        '--path-prefix', '/api/v3'
       ]);
 
       expect(release.getCall(0).args[0]).to.eql({
         token: auth.token,
         type: auth.type,
+      });
+
+      expect(release.getCall(0).args[1]).to.include({
         host: 'github.com',
         pathPrefix: '/api/v3',
         port: '80',
@@ -83,6 +86,7 @@ describe('Github Enterprise', function() {
       expect(GitHub.getCall(0).args[0]).to.eql(Object.assign(githubOpts, {
         version: '3.0.0'
       }));
+
     });
   });
 });

--- a/test/ghe.js
+++ b/test/ghe.js
@@ -66,16 +66,18 @@ describe('Github Enterprise', function() {
       var writerOpts = {};
       var cb = sinon.spy();
 
-      var githubOpts = Object.assign({
+      var githubOpts = {
         host: 'github.com',
         pathPrefix: '/api/v3',
         port: '80',
         protocol: 'https'
-      }, auth);
+      };
+
+      var options = Object.assign(githubOpts, changelogOpts);
 
       release(
-        githubOpts,
-        changelogOpts,
+        auth,
+        options,
         context,
         gitRawCommitsOpts,
         parserOpts,

--- a/test/test.js
+++ b/test/test.js
@@ -6,10 +6,8 @@ var Github = require('github');
 var githubRemoveAllReleases = require('github-remove-all-releases');
 var shell = require('shelljs');
 
-var AUTH = {
-  type: 'oauth',
-  token: process.env.TEST_CONVENTIONAL_GITHUB_RELEASER_TOKEN
-};
+var repo = require('./fixtures').repo
+var AUTH = require('./fixtures').auth
 
 var github = new Github({
   version: '3.0.0'
@@ -24,8 +22,8 @@ describe('conventional-github-releaser', function() {
     fs.writeFileSync('test1', '');
     shell.exec('git add --all && git commit -m"First commit"');
 
-    githubRemoveAllReleases(AUTH, 'stevemaotest', 'conventional-github-releaser-test', function() {
-      done();
+    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function () {
+      done()
     });
   });
 
@@ -65,16 +63,14 @@ describe('conventional-github-releaser', function() {
     shell.exec('git tag v1.0.0');
 
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
     }, function(err, responses) {
       expect(responses.length).to.equal(1);
       expect(responses[0].state).to.equal('fulfilled');
       github.releases.getRelease({
         // jscs:disable
-        owner: 'stevemaotest',
-        repo: 'conventional-github-releaser-test',
+        owner: repo.owner,
+        repo: repo.name,
         id: responses[0].value.id
         // jscs:enable
       }, function(err, data) {
@@ -86,9 +82,7 @@ describe('conventional-github-releaser', function() {
 
   it('should fail if a release exists', function(done) {
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
     }, function(err, responses) {
       expect(responses[0].state).to.equal('rejected');
 
@@ -102,16 +96,14 @@ describe('conventional-github-releaser', function() {
     shell.exec('git tag v2.0.0-beta');
 
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
     }, function(err, responses) {
       expect(responses.length).to.equal(1);
       expect(responses[0].state).to.equal('fulfilled');
       github.releases.getRelease({
         // jscs:disable
-        owner: 'stevemaotest',
-        repo: 'conventional-github-releaser-test',
+        owner: repo.owner,
+        repo: repo.name,
         id: responses[0].value.id
         // jscs:enable
       }, function(err, data) {
@@ -127,16 +119,14 @@ describe('conventional-github-releaser', function() {
     shell.exec('git tag v2.0.0');
 
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
       preset: 'angular'
     }, function(err, responses) {
       expect(responses.length).to.equal(1);
       github.releases.getRelease({
         // jscs:disable
-        owner: 'stevemaotest',
-        repo: 'conventional-github-releaser-test',
+        owner: repo.owner,
+        repo: repo.name,
         id: responses[0].value.id
         // jscs:enable
       }, function(err, data) {
@@ -155,9 +145,7 @@ describe('conventional-github-releaser', function() {
     shell.exec('git tag v4.0.0');
 
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
       releaseCount: 2
     }, function(err, responses) {
       expect(responses.length).to.equal(2);
@@ -167,9 +155,7 @@ describe('conventional-github-releaser', function() {
 
   it('should attempt to generate all releases', function(done) {
     conventionalGithubReleaser(AUTH, {
-      pkg: {
-        path: __dirname + '/fixtures/_package.json'
-      },
+      pkg: repo.pkg,
       releaseCount: 0
     }, function(err, responses) {
       expect(responses.length).to.equal(5);

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,8 @@ var Github = require('github');
 var githubRemoveAllReleases = require('github-remove-all-releases');
 var shell = require('shelljs');
 
-var repo = require('./fixtures').repo
-var AUTH = require('./fixtures').auth
+var repo = require('./fixtures').repo;
+var AUTH = require('./fixtures').auth;
 
 var github = new Github({
   version: '3.0.0'
@@ -22,8 +22,8 @@ describe('conventional-github-releaser', function() {
     fs.writeFileSync('test1', '');
     shell.exec('git add --all && git commit -m"First commit"');
 
-    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function () {
-      done()
+    githubRemoveAllReleases(AUTH, repo.owner, repo.name, function() {
+      done();
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,12 +37,12 @@ describe('conventional-github-releaser', function() {
 
   it('should throw if no cb is passed', function() {
     expect(function() {
-      conventionalGithubReleaser({});
+      conventionalGithubReleaser({token: 'anything'});
     }).to.throw('Expected an callback');
   });
 
   it('should error if git-raw-commits opts is wrong', function(done) {
-    conventionalGithubReleaser(AUTH, {}, {}, {
+    conventionalGithubReleaser(AUTH, {}, {
       version: '0.0.1'
     }, function(err) {
       expect(err).to.be.ok; // jshint ignore:line


### PR DESCRIPTION
Extends the command line interface to take github-\* related arguments and use it to configure a different github endpoint.

Changes:
- conventionalGithubReleaser() API is augmented  but arguments order is unchanged
- conventional-github-release CLI is augmented to receive new params but old ones are unchanged
- package.json Specify engine node >= 4.4.2 in order to make use of Object.assign function.

I believe it doesn't characterize a new major release ( although having GHE support is plausible to bump into a major change ). However it might break on nodejs older than 4.4.2.

Thanks.
