### PR TITLE
fix(cli): Fixed cli exit code for empty array

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -101,6 +101,11 @@ conventionalGithubReleaser({
     console.error(err.toString());
     process.exit(1);
   }
+  
+  if (0 === data.length) {
+    console.log('No GitHub releases created because no git tags available to work with.');
+    process.exit(0);
+  }
 
   var allRejected = true;
 

--- a/cli.js
+++ b/cli.js
@@ -103,7 +103,10 @@ conventionalGithubReleaser({
   }
 
   if (0 === data.length) {
-    console.log('No GitHub releases created because no git tags available to work with.');
+    if (flags.verbose) {
+      console.log('No GitHub releases created because no git tags available to work with.');
+    }
+
     process.exit(0);
   }
 

--- a/cli.js
+++ b/cli.js
@@ -101,7 +101,7 @@ conventionalGithubReleaser({
     console.error(err.toString());
     process.exit(1);
   }
-  
+
   if (0 === data.length) {
     console.log('No GitHub releases created because no git tags available to work with.');
     process.exit(0);

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,6 +1,7 @@
 'use strict';
 var expect = require('chai').expect;
 var fs = require('fs');
+var Q = require('q');
 var githubRemoveAllReleases = require('github-remove-all-releases');
 var shell = require('shelljs');
 var spawn = require('child_process').spawn;
@@ -61,6 +62,40 @@ describe('cli', function() {
       expect(code).to.equal(0);
 
       done();
+    });
+  });
+
+  it('should work with no releases', function(done) {
+    Q.Promise(function(resolve, reject) {
+      var cp = spawn(cliPath, ['--pkg',  __dirname + '/fixtures/_package.json', '-t', AUTH.token, '-v'], {
+        stdio: [process.stdin, null, null]
+      });
+
+      cp.on('error', function(code) {
+        reject('Process exits with code ' + code);
+      });
+
+      cp.on('close', function(code) {
+        expect(code).to.equal(0);
+
+        resolve();
+      });
+    }).then(function() {
+      // we call it a second time, because there no tags are left to create a release from
+      var cp = spawn(cliPath, ['--pkg',  __dirname + '/fixtures/_package.json', '-t', AUTH.token, '-v'], {
+        stdio: [process.stdin, null, null]
+      });
+
+      cp.on('error', function(code) {
+        done('Process exits with code ' + code);
+      });
+
+      cp.on('close', function(code) {
+        // this time we also expect the cli to exit with code 0 due to #17
+        expect(code).to.equal(0);
+
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #15
Before this fix the cli exited with status code 1 when getting an empty array.
Now it prints a message and exits with code 0.
