### PR TITLE
fix(gitRawCommitsOpts): apply user opts over our opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
       if (releaseCount !== 0) {
         gitRawCommitsOpts = assign({
           from: tags[releaseCount]
-        });
+        }, gitRawCommitsOpts);
       }
 
       gitRawCommitsOpts.to = gitRawCommitsOpts.to || tags[0];


### PR DESCRIPTION
When `releaseCount` equals any value other than 0, the original code
replaces the `gitRawCommitsOpts` object with our own configuration.

Instead, we need to apply the user's configuration over our configuration,
replacing our configuration where it conflicts with the user's configuration.