### PR TITLE
fix(transform): only match semantic version tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 var assign = require('object-assign');
 var conventionalChangelog = require('conventional-changelog');
-var dateFormat = require('dateformat');
 var Github = require('github');
 var gitSemverTags = require('git-semver-tags');
 var merge = require('lodash.merge');
 var Q = require('q');
 var semver = require('semver');
 var through = require('through2');
+var transform = require('./lib/transform');
 
 var github = new Github({
   version: '3.0.0'
@@ -40,20 +40,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
   writerOpts = changelogArgs[4];
 
   changelogOpts = merge({
-    transform: function(chunk, cb) {
-      if (typeof chunk.gitTags === 'string') {
-        var match = /tag:\s*(.+?)[,\)]/gi.exec(chunk.gitTags);
-        if (match) {
-          chunk.version = match[1];
-        }
-      }
-
-      if (chunk.committerDate) {
-        chunk.committerDate = dateFormat(chunk.committerDate, 'yyyy-mm-dd', true);
-      }
-
-      cb(null, chunk);
-    },
+    transform: transform,
     releaseCount: 1
   }, changelogOpts);
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var dateFormat = require('dateformat');
+var findVersions = require('find-versions');
+
+function transform(chunk, cb) {
+  if (typeof chunk.gitTags === 'string') {
+    chunk.version = findVersions(chunk.gitTags)[0];
+  }
+
+  if (chunk.committerDate) {
+    chunk.committerDate = dateFormat(chunk.committerDate, 'yyyy-mm-dd', true);
+  }
+
+  cb(null, chunk);
+}
+
+module.exports = transform;

--- a/lib/transform.spec.js
+++ b/lib/transform.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// jshint expr: true
+
+var chai = require('chai');
+var transform = require('./transform');
+
+var expect = chai.expect;
+
+describe('transform', function() {
+  beforeEach(function() {
+    this.chunk = {
+      gitTags: '',
+    };
+  });
+
+  it('should skip semantic version matching when gitTags isn\'t a string', function(done) {
+    this.chunk.gitTags = undefined;
+
+    transform(this.chunk, function(err, chunk) {
+      expect(chunk.version).to.be.undefined;
+      done();
+    });
+  });
+
+  it('should have no version when there are no tags', function(done) {
+    transform(this.chunk, function(err, chunk) {
+      expect(chunk.version).to.be.undefined;
+      done();
+    });
+  });
+
+  it('should not match invalid semantic version tag', function(done) {
+    this.chunk.gitTags = ' tag: release-18';
+
+    transform(this.chunk, function(err, chunk) {
+      expect(chunk.version).to.be.undefined;
+      done();
+    });
+  });
+
+  it('should match valid semantic version tag', function(done) {
+    this.chunk.gitTags = ' tag: release-18, tag: 1.1.20';
+
+    transform(this.chunk, function(err, chunk) {
+      expect(chunk.version).to.equal('1.1.20');
+      done();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "conventional-changelog": "^1.1.0",
     "dateformat": "^1.0.11",
+    "find-versions": "^2.0.0",
     "git-semver-tags": "^1.0.0",
     "github": "^0.2.4",
     "lodash.merge": "^4.0.2",


### PR DESCRIPTION
`conventional-changelog-writer` expects that the `version` property of a
commit object is a semantically valid version.

The previous version of the `transform` function would match against any
tag associated with the commit, and assign the first matched tag as the
commit's version.

If the matched tag is not a semantically valid version number,
`conventional-changelog-writer` will ignore the `version` property of
the commit object, and not successfully generate a changelog (since it
has no version on which to generate the changelog).

Therefore we update the `transform` function to only match against
semantically valid version tags when assigning the `version` property of
a commit object.