### PR TITLE
fix(cli): Remove broken error handling

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -115,19 +115,7 @@ conventionalGithubReleaser({
     process.exit(0);
   }
 
-  var allRejected = true;
-
-  for (var i = data.length - 1; i >= 0 ; i--) {
-    if (data[i].state === 'fulfilled') {
-      allRejected = false;
-      break;
-    }
-  }
-
-  if (allRejected) {
-    console.error(data);
-    process.exit(1);
-  } else if (flags.verbose) {
+  if (flags.verbose) {
     console.log(data);
   }
 });


### PR DESCRIPTION
data.state is not available when using Q.all() and only works with Q.allSettled().
As Q.all() is now used it does not make sense to do this check as the Promise
will be rejected immediately with an error if one of the calls to github fails.

This is broken since 7c1e4d911a4d793bb7d7489d55084704795ac24c

Although I'm not super sure about this fix as I think the referenced commit might have broken more stuff, as Q.all() is not waiting for all promises to be fulfilled and instead cancels everything as soon as one fails, leaving the user in an undefined state which requests actually were send and which ones were canceled.
In contrast Q.allSettled() waits till everything is finished and you have to handle failures yourself with the `state` property. 
Also the commit message of the change says that the user did not noticed that something failed which is wrong, as the `state` check was in place I guess. And it says it fixes #3 which seems unrelated.
So my ultimate solution would be to revert the commit in question but you need to decide :)

Fixes #46 

https://github.com/kriskowal/q#combination